### PR TITLE
Access app version and add test watch task

### DIFF
--- a/lib/index-test.js
+++ b/lib/index-test.js
@@ -1,0 +1,8 @@
+const gb = require('./index'),
+  package = require('../package.json');
+
+describe('gb', () => {
+  it('sets the version based on package.json', () => {
+    expect(gb.VERSION).toEqual(package.version);
+  });
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,7 @@
+const version = require('../package.json').version;
+
+const gb = {};
+
+gb.VERSION = version
+
+module.exports = gb;

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "geckoboard-node",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
+    "watch-test": "watch 'npm test'",
     "test": "JASMINE_CONFIG_PATH=jasmine.json jasmine"
   },
   "repository": {
@@ -22,6 +23,7 @@
   },
   "homepage": "https://github.com/geckoboard/geckoboard-node#readme",
   "devDependencies": {
-    "jasmine": "^2.4.1"
+    "jasmine": "^2.4.1",
+    "watch": "^0.18.0"
   }
 }


### PR DESCRIPTION
Had some time between tasks so I did this. The app accesses the version number given in `package.json` - I guess we can use this later for user-agent header? 
