### PR TITLE
Make API_HOST environment var less likely to clash

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const version = require('../package.json').version,
   findOrCreate = require('./find-or-create'),
   ping = require('./ping');
 
-const HOST = process.env.API_HOST || 'https://api.geckoboard.com',
+const HOST = process.env.GECKOBOARD_API_HOST || 'https://api.geckoboard.com',
   USER_AGENT =  `Geckoboard Node Client ${version}`;
 
 


### PR DESCRIPTION
Random systems might use `API_HOST` leading to unexpected sadness for customers. Prefixing with `GECKOBOARD` to make this a lot less likely.
