### PR TITLE
Handle unparseable JSON response for API requests

### DIFF
--- a/lib/api-request.js
+++ b/lib/api-request.js
@@ -10,9 +10,23 @@ module.exports = {
         return;
       }
       if (response.statusCode >= 200 && response.statusCode < 300) {
-        cb(null, JSON.parse(body));
+        var json;
+        try {
+          json = JSON.parse(body);
+        } catch (ex) {
+          return cb(new Error('Unparseable response'));
+        }
+        cb(null, json);
       } else {
-        cb(new Error(JSON.parse(body).error.message));
+        var json;
+        try {
+          json = JSON.parse(body);
+        } catch (ex) {
+          return cb(new Error('Unparseable response'));
+        }
+        if (!json&&!json.error&&!json.error.message)
+          return cb(new Error('Unknown error'));
+        cb(new Error(json.error.message));
       }
     }
     const requestOptions = {


### PR DESCRIPTION
```
worker-1 (err): SyntaxError: Unexpected end of input
worker-1 (err):     at Object.parse (native)
worker-1 (err):     at Request.callback [as _callback] (/srv/sites/prod/worker/gameengine/node_modules/geckoboard/lib/api-request.js:14:29)
worker-1 (err):     at Request.self.callback (/srv/sites/prod/worker/gameengine/node_modules/geckoboard/node_modules/request/request.js:187:22)
```

Getting these in our production environment. This pull request wraps a try/catch around JSON parsing to avoid uncaught errors crashing the server.