### PR TITLE
Check on response body

### DIFF
--- a/lib/api-request-test.js
+++ b/lib/api-request-test.js
@@ -47,6 +47,21 @@ describe('api', () => {
   });
 
   describe('when the response status is not 200', () => {
+    it('passes through error message', done => {
+      const apiRequest = api.apiRequest(HOST, API_KEY, USER_AGENT);
+      const ERROR_MESSAGE = 'problem';
+      const ERROR_RESPONSE_BODY = { error: { message: ERROR_MESSAGE } };
+
+      nock(HOST)[METHOD](ENDPOINT)
+      .reply(400, ERROR_RESPONSE_BODY);
+
+      apiRequest(METHOD, OPTIONS, (err, body) => {
+        expect(body).toBeUndefined()
+        expect(err).toEqual(new Error(ERROR_MESSAGE))
+        done();
+      });
+    });
+
     describe('and the response JSON is not formatted correctly', () => {
       it('returns an appropriate error', (done) => {
         const apiRequest = api.apiRequest(HOST, API_KEY, USER_AGENT);

--- a/lib/api-request.js
+++ b/lib/api-request.js
@@ -19,7 +19,7 @@ module.exports = {
       } else {
         try {
           const parsedBody = JSON.parse(body);
-          if (!parsedBody || !parsedBody.error || !!parsedBody.error.message) {
+          if (!parsedBody || !parsedBody.error || !parsedBody.error.message) {
             cb(new Error('Unknown error'));
           } else {
             cb(new Error(parsedBody.error.message));


### PR DESCRIPTION
It should check if `parsedBody.error.message` is falsey, but with `!!` it simply casts it to a bool, so for a valid error, it was evaluating as truthy e.g. `false || false || true` => `true`, so `Unknown error` was being returned when it should be branching into the `else`. In this specific case, the raw error message was

```
'{"error":{"message":"A dataset with different fields already exists with the ID \"base.deals09\""}}'
```