### PR TITLE
Create dataset

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -50,6 +50,7 @@ describe('Geckoboard', () => {
     expect(async () => await gb.ping()).rejects.toThrow(
       new Error('Your API key is invalid'),
     );
+    expect(() => mockAgent.assertNoPendingInterceptors()).not.toThrow();
   });
 
   it('will error with default message when error is upexpected', async () => {
@@ -67,6 +68,7 @@ describe('Geckoboard', () => {
     expect(async () => await gb.ping()).rejects.toThrow(
       new Error('Something went wrong with the request'),
     );
+    expect(() => mockAgent.assertNoPendingInterceptors()).not.toThrow();
   });
 
   it('can create a dataset', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -81,6 +81,7 @@ describe('Geckoboard', () => {
         headers: {
           Authorization: `Basic ${btoa('API_KEY:')}`,
           'User-Agent': 'Geckoboard Node Client 2.0.0',
+          'Content-type': 'application/json',
         },
         body: JSON.stringify({
           fields: {
@@ -164,6 +165,7 @@ describe('Geckoboard', () => {
         headers: {
           Authorization: `Basic ${btoa('API_KEY:')}`,
           'User-Agent': 'Geckoboard Node Client 2.0.0',
+          'Content-type': 'application/json',
         },
         body: JSON.stringify({
           fields: {
@@ -192,5 +194,6 @@ describe('Geckoboard', () => {
     expect(async () => await dataset.create()).rejects.toThrow(
       new Error('Something went wrong with the request'),
     );
+    expect(() => mockAgent.assertNoPendingInterceptors()).not.toThrow();
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -68,4 +68,129 @@ describe('Geckoboard', () => {
       new Error('Something went wrong with the request'),
     );
   });
+
+  it('can create a dataset', async () => {
+    const mockAgent = new MockAgent();
+    setGlobalDispatcher(mockAgent);
+
+    const mockPool = mockAgent.get('https://api.geckoboard.com');
+    mockPool
+      .intercept({
+        method: 'PUT',
+        path: '/datasets/steps.by.day',
+        headers: {
+          Authorization: `Basic ${btoa('API_KEY:')}`,
+          'User-Agent': 'Geckoboard Node Client 2.0.0',
+        },
+        body: JSON.stringify({
+          fields: {
+            steps: {
+              type: 'number',
+              name: 'Steps',
+              optional: false,
+            },
+            timestamp: {
+              type: 'datetime',
+              name: 'Date',
+            },
+          },
+          unique_by: ['timestamp'],
+        }),
+      })
+      .reply(
+        200,
+        JSON.stringify({
+          id: 'steps.by.day',
+          fields: {
+            steps: {
+              type: 'number',
+              name: 'Steps',
+              optional: false,
+            },
+            timestamp: {
+              type: 'datetime',
+              name: 'Date',
+            },
+          },
+          unique_by: ['timestamp'],
+        }),
+      );
+
+    const gb = new Geckoboard('API_KEY');
+    const dataset = gb.defineDataset({
+      id: 'steps.by.day',
+      fields: {
+        steps: {
+          type: 'number',
+          name: 'Steps',
+          optional: false,
+        },
+        timestamp: {
+          type: 'datetime',
+          name: 'Date',
+        },
+      },
+      uniqueBy: ['timestamp'],
+    });
+    const schema = await dataset.create();
+
+    expect(schema).toEqual({
+      id: 'steps.by.day',
+      fields: {
+        steps: {
+          type: 'number',
+          name: 'Steps',
+          optional: false,
+        },
+        timestamp: {
+          type: 'datetime',
+          name: 'Date',
+        },
+      },
+      uniqueBy: ['timestamp'],
+    });
+    expect(() => mockAgent.assertNoPendingInterceptors()).not.toThrow();
+  });
+
+  it('will error if there is an issue creating a dataset', async () => {
+    const mockAgent = new MockAgent();
+    setGlobalDispatcher(mockAgent);
+
+    const mockPool = mockAgent.get('https://api.geckoboard.com');
+    mockPool
+      .intercept({
+        method: 'PUT',
+        path: '/datasets/problems.by.day',
+        headers: {
+          Authorization: `Basic ${btoa('API_KEY:')}`,
+          'User-Agent': 'Geckoboard Node Client 2.0.0',
+        },
+        body: JSON.stringify({
+          fields: {
+            timestamp: {
+              type: 'datetime',
+              name: 'Date',
+            },
+          },
+          unique_by: ['timestamp'],
+        }),
+      })
+      .reply(500, '{}');
+
+    const gb = new Geckoboard('API_KEY');
+    const dataset = gb.defineDataset({
+      id: 'problems.by.day',
+      fields: {
+        timestamp: {
+          type: 'datetime',
+          name: 'Date',
+        },
+      },
+      uniqueBy: ['timestamp'],
+    });
+
+    expect(async () => await dataset.create()).rejects.toThrow(
+      new Error('Something went wrong with the request'),
+    );
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -135,23 +135,8 @@ describe('Geckoboard', () => {
       },
       uniqueBy: ['timestamp'],
     });
-    const schema = await dataset.create();
+    await dataset.create();
 
-    expect(schema).toEqual({
-      id: 'steps.by.day',
-      fields: {
-        steps: {
-          type: 'number',
-          name: 'Steps',
-          optional: false,
-        },
-        timestamp: {
-          type: 'datetime',
-          name: 'Date',
-        },
-      },
-      uniqueBy: ['timestamp'],
-    });
     expect(() => mockAgent.assertNoPendingInterceptors()).not.toThrow();
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,18 +246,10 @@ type KeysMatching<T, V> = {
   [K in keyof T]-?: T[K] extends V ? K : never;
 }[keyof T];
 
-type uniqueBy<T> = Array<
-  KeysMatching<T, StringField | DateField | DateTimeField>
->;
-
 type Schema<T extends Fields> = {
   id: string;
   fields: T;
-  uniqueBy: uniqueBy<T>;
-};
-
-type SchemaResponse<T extends Fields> = Pick<Schema<T>, 'id' | 'fields'> & {
-  unique_by: uniqueBy<T>;
+  uniqueBy: Array<KeysMatching<T, StringField | DateField | DateTimeField>>;
 };
 
 type FieldType<T> = T extends DateField | DateTimeField | StringField
@@ -296,18 +288,12 @@ class Dataset<T extends Fields> {
     this.gb = gb;
   }
 
-  async create(): Promise<Schema<T>> {
+  async create(): Promise<void> {
     const { id, fields, uniqueBy } = this;
-    const res = await this.gb.request('PUT', `/datasets/${id}`, {
+    await this.gb.request('PUT', `/datasets/${id}`, {
       fields,
       unique_by: uniqueBy,
     });
-    const json = (await res.json()) as SchemaResponse<T>;
-    return {
-      id: json.id,
-      fields: json.fields,
-      uniqueBy: json.unique_by,
-    } as Schema<T>;
   }
 
   append(items: DatasetDataItem<T>[], deleteBy?: keyof T): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -347,7 +347,7 @@ class Geckoboard {
     if (method === 'POST' || method === 'PUT') {
       headers.set('Content-Type', 'application/json');
     }
-    const res = await fetch(`https://api.geckoboard.com${path}`, {
+    const res = await fetch(new URL(path, 'https://api.geckoboard.com'), {
       body: JSON.stringify(body),
       method: method,
       headers,

--- a/src/index.ts
+++ b/src/index.ts
@@ -340,13 +340,17 @@ class Geckoboard {
     body?: object,
   ): Promise<Response> {
     const auth = btoa(`${this.apiKey}:`);
+    const headers = new Headers({
+      Authorization: `Basic ${auth}`,
+      'User-Agent': USER_AGENT,
+    });
+    if (method === 'POST' || method === 'PUT') {
+      headers.set('Content-Type', 'application/json');
+    }
     const res = await fetch(`https://api.geckoboard.com${path}`, {
       body: JSON.stringify(body),
       method: method,
-      headers: {
-        Authorization: `Basic ${auth}`,
-        'User-Agent': USER_AGENT,
-      },
+      headers,
     });
     if (res.status !== 200) {
       const json = (await res.json()) as ErrorResponse;


### PR DESCRIPTION
This change allows us to make a request to the API to create (or find, it's an idempotent request) a dataset. 
The API does return the schema of the created dataset but we will assume the success of the request is enough to confirm we correctly created the dataset - so we won't return the schema from the method call. 