### PR TITLE
Append and Replace data, Delete dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ console.log(schema)
 #### Update a dataset
 ```
 
-await dataset.post([
+await dataset.append([
   { count: 1, day: '2023-10-10' },
   { count: 2, day: '2023-10-11' },
   { count: 3, day: '2023-10-12' },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,67 +1,6 @@
 import Geckoboard from './index';
 import { MockAgent, setGlobalDispatcher, Interceptable } from 'undici';
 
-const prepareDatasetForCreation = (mockPool: Interceptable) => {
-  mockPool
-    .intercept({
-      method: 'PUT',
-      path: '/datasets/steps.by.day',
-      headers: {
-        Authorization: `Basic ${btoa('API_KEY:')}`,
-        'User-Agent': 'Geckoboard Node Client 2.0.0',
-        'Content-type': 'application/json',
-      },
-      body: JSON.stringify({
-        fields: {
-          steps: {
-            type: 'number',
-            name: 'Steps',
-            optional: false,
-          },
-          timestamp: {
-            type: 'datetime',
-            name: 'Date',
-          },
-        },
-        unique_by: ['timestamp'],
-      }),
-    })
-    .reply(
-      200,
-      JSON.stringify({
-        id: 'steps.by.day',
-        fields: {
-          steps: {
-            type: 'number',
-            name: 'Steps',
-            optional: false,
-          },
-          timestamp: {
-            type: 'datetime',
-            name: 'Date',
-          },
-        },
-        unique_by: ['timestamp'],
-      }),
-    );
-
-  const gb = new Geckoboard('API_KEY');
-  return gb.defineDataset({
-    id: 'steps.by.day',
-    fields: {
-      steps: {
-        type: 'number',
-        name: 'Steps',
-        optional: false,
-      },
-      timestamp: {
-        type: 'datetime',
-        name: 'Date',
-      },
-    },
-    uniqueBy: ['timestamp'],
-  });
-};
 describe('Geckoboard', () => {
   let mockAgent: MockAgent;
   let mockPool: Interceptable;
@@ -134,7 +73,65 @@ describe('Geckoboard', () => {
   });
 
   it('can create a dataset', async () => {
-    const dataset = prepareDatasetForCreation(mockPool);
+    mockPool
+      .intercept({
+        method: 'PUT',
+        path: '/datasets/steps.by.day',
+        headers: {
+          Authorization: `Basic ${btoa('API_KEY:')}`,
+          'User-Agent': 'Geckoboard Node Client 2.0.0',
+          'Content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          fields: {
+            steps: {
+              type: 'number',
+              name: 'Steps',
+              optional: false,
+            },
+            timestamp: {
+              type: 'datetime',
+              name: 'Date',
+            },
+          },
+          unique_by: ['timestamp'],
+        }),
+      })
+      .reply(
+        200,
+        JSON.stringify({
+          id: 'steps.by.day',
+          fields: {
+            steps: {
+              type: 'number',
+              name: 'Steps',
+              optional: false,
+            },
+            timestamp: {
+              type: 'datetime',
+              name: 'Date',
+            },
+          },
+          unique_by: ['timestamp'],
+        }),
+      );
+
+    const gb = new Geckoboard('API_KEY');
+    const dataset = gb.defineDataset({
+      id: 'steps.by.day',
+      fields: {
+        steps: {
+          type: 'number',
+          name: 'Steps',
+          optional: false,
+        },
+        timestamp: {
+          type: 'datetime',
+          name: 'Date',
+        },
+      },
+      uniqueBy: ['timestamp'],
+    });
     await dataset.create();
   });
 
@@ -205,8 +202,7 @@ describe('Geckoboard', () => {
         }),
       })
       .reply(200, '{}');
-    const dataset = prepareDatasetForCreation(mockPool);
-    await dataset.create();
+    const dataset = prepareDatasetForCreation();
     dataset.append([
       {
         timestamp: '2018-01-01T12:00:00Z',
@@ -243,8 +239,7 @@ describe('Geckoboard', () => {
         }),
       })
       .reply(500, '{}');
-    const dataset = prepareDatasetForCreation(mockPool);
-    await dataset.create();
+    const dataset = prepareDatasetForCreation();
     expect(
       async () =>
         await dataset.append([
@@ -284,8 +279,7 @@ describe('Geckoboard', () => {
         }),
       })
       .reply(200, '{}');
-    const dataset = prepareDatasetForCreation(mockPool);
-    await dataset.create();
+    const dataset = prepareDatasetForCreation();
     dataset.replace([
       {
         timestamp: '2018-01-01T12:00:00Z',
@@ -322,8 +316,7 @@ describe('Geckoboard', () => {
         }),
       })
       .reply(500, '{}');
-    const dataset = prepareDatasetForCreation(mockPool);
-    await dataset.create();
+    const dataset = prepareDatasetForCreation();
     expect(
       async () =>
         await dataset.replace([
@@ -346,8 +339,7 @@ describe('Geckoboard', () => {
         },
       })
       .reply(200, '{}');
-    const dataset = prepareDatasetForCreation(mockPool);
-    await dataset.create();
+    const dataset = prepareDatasetForCreation();
     await dataset.delete();
   });
 
@@ -362,10 +354,28 @@ describe('Geckoboard', () => {
         },
       })
       .reply(500, '{}');
-    const dataset = prepareDatasetForCreation(mockPool);
-    await dataset.create();
+    const dataset = prepareDatasetForCreation();
     expect(async () => await dataset.delete()).rejects.toThrow(
       new Error('Something went wrong with the request'),
     );
   });
 });
+
+const prepareDatasetForCreation = () => {
+  const gb = new Geckoboard('API_KEY');
+  return gb.defineDataset({
+    id: 'steps.by.day',
+    fields: {
+      steps: {
+        type: 'number',
+        name: 'Steps',
+        optional: false,
+      },
+      timestamp: {
+        type: 'datetime',
+        name: 'Date',
+      },
+    },
+    uniqueBy: ['timestamp'],
+  });
+};

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -334,4 +334,38 @@ describe('Geckoboard', () => {
         ]),
     ).rejects.toThrow(new Error('Something went wrong with the request'));
   });
+
+  it('can delete a dataset', async () => {
+    mockPool
+      .intercept({
+        method: 'DELETE',
+        path: '/datasets/steps.by.day',
+        headers: {
+          Authorization: `Basic ${btoa('API_KEY:')}`,
+          'User-Agent': 'Geckoboard Node Client 2.0.0',
+        },
+      })
+      .reply(200, '{}');
+    const dataset = prepareDatasetForCreation(mockPool);
+    await dataset.create();
+    await dataset.delete();
+  });
+
+  it('will error if there is an issue deleting a dataset', async () => {
+    mockPool
+      .intercept({
+        method: 'DELETE',
+        path: '/datasets/steps.by.day',
+        headers: {
+          Authorization: `Basic ${btoa('API_KEY:')}`,
+          'User-Agent': 'Geckoboard Node Client 2.0.0',
+        },
+      })
+      .reply(500, '{}');
+    const dataset = prepareDatasetForCreation(mockPool);
+    await dataset.create();
+    expect(async () => await dataset.delete()).rejects.toThrow(
+      new Error('Something went wrong with the request'),
+    );
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -54,7 +54,7 @@ describe('Geckoboard', () => {
       );
 
     const gb = new Geckoboard('BAD_API_KEY');
-    expect(async () => await gb.ping()).rejects.toThrow(
+    await expect(gb.ping()).rejects.toThrow(
       new Error('Your API key is invalid'),
     );
   });
@@ -67,7 +67,7 @@ describe('Geckoboard', () => {
       .reply(500, {});
 
     const gb = new Geckoboard('BAD_API_KEY');
-    expect(async () => await gb.ping()).rejects.toThrow(
+    await expect(gb.ping()).rejects.toThrow(
       new Error('Something went wrong with the request'),
     );
   });
@@ -169,7 +169,7 @@ describe('Geckoboard', () => {
       uniqueBy: ['timestamp'],
     });
 
-    expect(async () => await dataset.create()).rejects.toThrow(
+    await expect(dataset.create()).rejects.toThrow(
       new Error('Something went wrong with the request'),
     );
   });
@@ -202,8 +202,8 @@ describe('Geckoboard', () => {
         }),
       })
       .reply(200, '{}');
-    const dataset = prepareDatasetForCreation();
-    dataset.append([
+    const dataset = prepareDataset();
+    await dataset.append([
       {
         timestamp: '2018-01-01T12:00:00Z',
         steps: 819,
@@ -239,15 +239,14 @@ describe('Geckoboard', () => {
         }),
       })
       .reply(500, '{}');
-    const dataset = prepareDatasetForCreation();
-    expect(
-      async () =>
-        await dataset.append([
-          {
-            timestamp: '2018-01-01T12:00:00Z',
-            steps: 819,
-          },
-        ]),
+    const dataset = prepareDataset();
+    await expect(
+      dataset.append([
+        {
+          timestamp: '2018-01-01T12:00:00Z',
+          steps: 819,
+        },
+      ]),
     ).rejects.toThrow(new Error('Something went wrong with the request'));
   });
 
@@ -279,8 +278,8 @@ describe('Geckoboard', () => {
         }),
       })
       .reply(200, '{}');
-    const dataset = prepareDatasetForCreation();
-    dataset.replace([
+    const dataset = prepareDataset();
+    await dataset.replace([
       {
         timestamp: '2018-01-01T12:00:00Z',
         steps: 819,
@@ -316,15 +315,14 @@ describe('Geckoboard', () => {
         }),
       })
       .reply(500, '{}');
-    const dataset = prepareDatasetForCreation();
-    expect(
-      async () =>
-        await dataset.replace([
-          {
-            timestamp: '2018-01-01T12:00:00Z',
-            steps: 819,
-          },
-        ]),
+    const dataset = prepareDataset();
+    await expect(
+      dataset.replace([
+        {
+          timestamp: '2018-01-01T12:00:00Z',
+          steps: 819,
+        },
+      ]),
     ).rejects.toThrow(new Error('Something went wrong with the request'));
   });
 
@@ -339,7 +337,7 @@ describe('Geckoboard', () => {
         },
       })
       .reply(200, '{}');
-    const dataset = prepareDatasetForCreation();
+    const dataset = prepareDataset();
     await dataset.delete();
   });
 
@@ -354,14 +352,14 @@ describe('Geckoboard', () => {
         },
       })
       .reply(500, '{}');
-    const dataset = prepareDatasetForCreation();
-    expect(async () => await dataset.delete()).rejects.toThrow(
+    const dataset = prepareDataset();
+    await expect(dataset.delete()).rejects.toThrow(
       new Error('Something went wrong with the request'),
     );
   });
 });
 
-const prepareDatasetForCreation = () => {
+const prepareDataset = () => {
   const gb = new Geckoboard('API_KEY');
   return gb.defineDataset({
     id: 'steps.by.day',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -255,4 +255,83 @@ describe('Geckoboard', () => {
         ]),
     ).rejects.toThrow(new Error('Something went wrong with the request'));
   });
+
+  it('can replace data in a dataset', async () => {
+    mockPool
+      .intercept({
+        method: 'PUT',
+        path: '/datasets/steps.by.day/data',
+        headers: {
+          Authorization: `Basic ${btoa('API_KEY:')}`,
+          'User-Agent': 'Geckoboard Node Client 2.0.0',
+          'Content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          data: [
+            {
+              timestamp: '2018-01-01T12:00:00Z',
+              steps: 819,
+            },
+            {
+              timestamp: '2018-01-02T12:00:00Z',
+              steps: 409,
+            },
+            {
+              timestamp: '2018-01-03T12:00:00Z',
+              steps: 164,
+            },
+          ],
+        }),
+      })
+      .reply(200, '{}');
+    const dataset = prepareDatasetForCreation(mockPool);
+    await dataset.create();
+    dataset.replace([
+      {
+        timestamp: '2018-01-01T12:00:00Z',
+        steps: 819,
+      },
+      {
+        timestamp: '2018-01-02T12:00:00Z',
+        steps: 409,
+      },
+      {
+        timestamp: '2018-01-03T12:00:00Z',
+        steps: 164,
+      },
+    ]);
+  });
+
+  it('will error if there is an issue replacing a dataset', async () => {
+    mockPool
+      .intercept({
+        method: 'PUT',
+        path: '/datasets/steps.by.day/data',
+        headers: {
+          Authorization: `Basic ${btoa('API_KEY:')}`,
+          'User-Agent': 'Geckoboard Node Client 2.0.0',
+          'Content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          data: [
+            {
+              timestamp: '2018-01-01T12:00:00Z',
+              steps: 819,
+            },
+          ],
+        }),
+      })
+      .reply(500, '{}');
+    const dataset = prepareDatasetForCreation(mockPool);
+    await dataset.create();
+    expect(
+      async () =>
+        await dataset.replace([
+          {
+            timestamp: '2018-01-01T12:00:00Z',
+            steps: 819,
+          },
+        ]),
+    ).rejects.toThrow(new Error('Something went wrong with the request'));
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,9 +296,12 @@ class Dataset<T extends Fields> {
     });
   }
 
-  append(items: DatasetDataItem<T>[], deleteBy?: keyof T): Promise<void> {
-    console.log({ items, deleteBy });
-    return Promise.resolve();
+  async append(items: DatasetDataItem<T>[], deleteBy?: keyof T): Promise<void> {
+    const { id } = this;
+    await this.gb.request('POST', `/datasets/${id}/data`, {
+      data: items,
+      deleteBy,
+    });
   }
 
   replace(items: DatasetDataItem<T>[]): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,9 +304,11 @@ class Dataset<T extends Fields> {
     });
   }
 
-  replace(items: DatasetDataItem<T>[]): Promise<void> {
-    console.log({ items });
-    return Promise.resolve();
+  async replace(items: DatasetDataItem<T>[]): Promise<void> {
+    const { id } = this;
+    await this.gb.request('PUT', `/datasets/${id}/data`, {
+      data: items,
+    });
   }
 
   delete(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,8 +311,9 @@ class Dataset<T extends Fields> {
     });
   }
 
-  delete(): Promise<void> {
-    return Promise.resolve();
+  async delete(): Promise<void> {
+    const { id } = this;
+    await this.gb.request('DELETE', `/datasets/${id}`);
   }
 }
 


### PR DESCRIPTION
This change adds implementation for appending, replacing data to a dataset as well as deleting a dataset.
I still intend to add support for using `Date` instances for date and datetime fields at a later point. 
I've  moved the repeated `expect(() => mockAgent.assertNoPendingInterceptors()).not.toThrow();` assertion to an `afterEach`. For now , this means some `it` blocks have no expectations - but will fail in the `afterEach` if the correct requests are not made.