### PR TITLE
Add a CI task to NPM publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,3 +49,5 @@ workflows:
           filters:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: Publish to NPM
           command: |
             npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-            npm publish --dry-run
+            npm publish 
 
 workflows:
   lint-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,26 @@ jobs:
       - checkout
       - run: npm clean-install
       - run: npm run lint 
+  publish:
+    executor: node
+    steps:
+      - checkout
+      - run: npm clean-install
+      - run: npm run build
+      - run:
+          name: Publish to NPM
+          command: |
+            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+            npm publish --dry-run
 
 workflows:
   lint-and-test:
     jobs:
       - lint
       - test
+  tagged-build:
+    jobs:
+      - publish:
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ const dataset = gb.defineDataset({
   uniqueBy: ['day'],
 });
 
-const schema = await dataset.create();
-console.log(schema)
+await dataset.create();
 ```
 
 #### Update a dataset

--- a/README.md
+++ b/README.md
@@ -169,3 +169,11 @@ npm run test
 ## Development
 
 You can change the host against which requests will be made by setting the `GECKOBOARD_API_HOST` environment variable to the full URL of the instance you wish to use.
+
+## Notes for maintainers
+
+To publish a new version of the module to NPM, you need to run the following command
+```
+npm version X.X.X
+```
+Where X.X.X is the version you want to release. This will create a tagged commit, once this commit is pushed to github, it will trigger publishing to NPM.


### PR DESCRIPTION
This change will cause Circle CI to attempt to publish the current version of the module to NPM when we include a commit tagged with a version number. Tagged commits can be created by `npm version X.X.X`. 

Should we include documentation of publishing in the public-facing readme?

This was the output when I tested the CI with a tagged commit created by `npm version 2.0.0 --allow-same-version` using the `--dry-run` flag with `npm publish`:
```
npm notice 
npm notice 📦  geckoboard@2.0.0
npm notice === Tarball Contents === 
npm notice 1.0kB  .circleci/config.yml
npm notice 330B   .eslintrc           
npm notice 51B    .prettierrc         
npm notice 3.9kB  README.md           
npm notice 3.9kB  dist/index.d.mts    
npm notice 3.9kB  dist/index.d.ts     
npm notice 5.7kB  dist/index.js       
npm notice 11.2kB dist/index.js.map   
npm notice 4.8kB  dist/index.mjs      
npm notice 11.2kB dist/index.mjs.map  
npm notice 69B    jest-setup.js       
npm notice 166B   jest.config.js      
npm notice 996B   package.json        
npm notice 20.2kB src/index.test.ts   
npm notice 7.1kB  src/index.ts        
npm notice 12.3kB tsconfig.json       
npm notice 265B   tsup.config.ts      
npm notice === Tarball Details === 
npm notice name:          geckoboard                              
npm notice version:       2.0.0                                   
npm notice filename:      geckoboard-2.0.0.tgz                    
npm notice package size:  16.9 kB                                 
npm notice unpacked size: 87.2 kB                                 
npm notice shasum:        36442f7571debba73a48201020b1658eb7311c4b
npm notice integrity:     sha512-ozKa1ngRtsrWW[...]ALBlwbhf3mOKg==
npm notice total files:   17                                      
npm notice 
npm notice Publishing to https://registry.npmjs.org/ (dry-run)
+ geckoboard@2.0.0
```
