### PR TITLE
Use named export for Geckoboard constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The latest documentation and user guide can be found on the Geckoboard developer
 #### Find or create a new dataset
 
 ```
-import Geckoboard from 'geckoboard';
+import { Geckoboard } from 'geckoboard';
 
 const API_KEY = 'YOUR_API_KEY';
 
@@ -143,7 +143,7 @@ await dataset.append([
 ### Ping to test connection
 
 ```
-import Geckoboard from 'geckoboard';
+import { Geckoboard } from 'geckoboard';
 
 const API_KEY = 'YOUR_API_KEY';
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import Geckoboard from './index';
+import { Geckoboard } from './index';
 import { MockAgent, setGlobalDispatcher, Interceptable } from 'undici';
 
 describe('Geckoboard', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,7 +358,7 @@ class Dataset<T extends Fields> {
   }
 }
 
-class Geckoboard {
+export class Geckoboard {
   apiKey: string;
   apiHost: string;
   version: string;
@@ -405,5 +405,3 @@ class Geckoboard {
     await this.request('GET', '/');
   }
 }
-
-export default Geckoboard;


### PR DESCRIPTION
This means we don't have to do e.g.
```
const Geckoboard = require('geckoboard').default
```
and instead can do
```
const { Geckoboard } = require('geckoboard')
```
which feels a bit nicer to read.